### PR TITLE
Fix issues with out of bounds layout attributes

### DIFF
--- a/CollectionViewPagingLayout/Lib/CollectionViewPagingLayout.swift
+++ b/CollectionViewPagingLayout/Lib/CollectionViewPagingLayout.swift
@@ -13,9 +13,7 @@ public protocol CollectionViewPagingLayoutDelegate: class {
 }
 
 public class CollectionViewPagingLayout: UICollectionViewLayout {
-    
-    // MARK: Properties
-    
+
     public var numberOfVisibleItems: Int?
     
     public var scrollDirection: UICollectionView.ScrollDirection = .horizontal
@@ -32,44 +30,28 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
         if scrollDirection == .horizontal {
             return CGSize(width: CGFloat(numberOfItems) * visibleRect.width, height: visibleRect.height - safeAreaTopBottom)
         } else {
-             return CGSize(width: visibleRect.width - safeAreaLeftRight, height: CGFloat(numberOfItems) * visibleRect.height)
+            return CGSize(width: visibleRect.width - safeAreaLeftRight, height: CGFloat(numberOfItems) * visibleRect.height)
         }
     }
     
-    private(set) var currentPage: Int
+    private(set) var currentPage: Int = 0
     
     private var visibleRect: CGRect {
-        guard let collectionView = collectionView else {
-            return .zero
-        }
-        return CGRect(origin: collectionView.contentOffset, size: collectionView.bounds.size)
+        collectionView.map { CGRect(origin: $0.contentOffset, size: $0.bounds.size) } ?? .zero
     }
     
     private var numberOfItems: Int {
         collectionView?.numberOfItems(inSection: 0) ?? 0
     }
-    
-    
-    // MARK: Life cycle
-    
-    public override init() {
-        currentPage = 0
-        super.init()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("not available")
-    }
-    
-    
+
     // MARK: Public functions
     
     public func setCurrentPage(_ page: Int, animated: Bool = true) {
         var offset = (scrollDirection == .horizontal ? visibleRect.width : visibleRect.height) * CGFloat(page)
         offset = max(0, offset)
         offset = scrollDirection == .horizontal ? min(collectionViewContentSize.width - visibleRect.width, offset) : min(collectionViewContentSize.height - visibleRect.height, offset)
-        collectionView?.setContentOffset(scrollDirection == .horizontal ? .init(x: offset, y: 0) : .init(x: 0, y: offset),
-                                         animated: animated)
+        let contentOffset = scrollDirection == .horizontal ? CGPoint(x: offset, y: 0) : CGPoint(x: 0, y: offset)
+        collectionView?.setContentOffset(contentOffset, animated: animated)
     }
     
     public func goToNextPage(animated: Bool = true) {
@@ -80,44 +62,56 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
         setCurrentPage(currentPage - 1, animated: animated)
     }
     
-    
-    // MARK: UICollectionViewFlowLayout
+    // MARK: UICollectionViewLayout
     
     override public func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
         return true
     }
     
     override public func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        var attributesArray: [UICollectionViewLayoutAttributes] = []
-        var numberOfAttributes = min(numberOfItems, numberOfVisibleItems ?? numberOfItems)
-        numberOfAttributes = max(numberOfAttributes, 3)
-        if numberOfAttributes % 2 == 0 {
-            numberOfAttributes += 1
-        }
+        let totalNumberOfItems = numberOfItems
+        let attributesCount = numberOfVisibleItems ?? totalNumberOfItems
         
-        let currentIndex = Int(round(scrollDirection == .horizontal ? (visibleRect.minX / visibleRect.width) : (visibleRect.minY / visibleRect.height)))
-        let startIndex = max(0, currentIndex - (numberOfAttributes - 1)/2)
+        let currentScrollOffset = self.currentScrollOffset
+        let currentPageIndex = Int(round(currentScrollOffset))
         
-        for index in startIndex..<startIndex + numberOfAttributes {
-            let attributes = UICollectionViewLayoutAttributes(forCellWith: .init(row: index, section: 0))
-            let progress = CGFloat(index) - (scrollDirection == .horizontal ? (visibleRect.minX / visibleRect.width) : (visibleRect.minY / visibleRect.height))
+        let visibleRangeMid = attributesCount / 2
+        let startIndex = max(0, currentPageIndex - visibleRangeMid)
+        let endIndex = min(totalNumberOfItems, currentPageIndex + visibleRangeMid)
+        
+        let visibleRect = self.visibleRect
+
+        var layoutAttributes: [UICollectionViewLayoutAttributes] = []
+        for itemIndex in startIndex..<endIndex {
+            let pageIndex = CGFloat(itemIndex)
+            let cellAttributes = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: itemIndex, section: 0))
+            
+            let progress = pageIndex - currentScrollOffset
             var zIndex = Int(-abs(round(progress)))
+
             if let numberOfVisibleItems = numberOfVisibleItems, abs(progress) >= CGFloat(numberOfVisibleItems) - 1 {
-                attributes.isHidden = true
+                cellAttributes.isHidden = true
             } else {
-                let cell = collectionView?.cellForItem(at: attributes.indexPath)
+                let cell = collectionView?.cellForItem(at: cellAttributes.indexPath)
+                // nil cell when not visible
                 if cell == nil || cell is TransformableView {
-                    attributes.frame = visibleRect
+                    cellAttributes.frame = visibleRect
                     (cell as? TransformableView)?.transform(progress: progress)
                     zIndex = (cell as? TransformableView)?.zPosition(progress: progress) ?? zIndex
                 } else {
-                    attributes.frame = .init(origin: .init(x: CGFloat(index) * visibleRect.width, y: 0), size: visibleRect.size)
+                    cellAttributes.frame = CGRect(
+                        x: pageIndex * visibleRect.width,
+                        y: 0,
+                        width: visibleRect.size.width,
+                        height: visibleRect.size.height
+                    )
                 }
             }
-            attributes.zIndex = zIndex
-            attributesArray.append(attributes)
+            cellAttributes.zIndex = zIndex
+            layoutAttributes.append(cellAttributes)
         }
-        return attributesArray
+
+        return layoutAttributes
     }
     
     override public func invalidateLayout() {
@@ -125,8 +119,12 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
         updateCurrentPageIfNeeded()
     }
     
+    // MARK: Private
     
-    // MARK: Private functions
+    private var currentScrollOffset: CGFloat {
+        let visibleRect = self.visibleRect
+        return scrollDirection == .horizontal ? (visibleRect.minX / max(visibleRect.width, 1)) : (visibleRect.minY / max(visibleRect.height, 1))
+    }
     
     private func updateCurrentPageIfNeeded() {
         var currentPage: Int = 0


### PR DESCRIPTION
I was having issues with error messages for layout attributes being created for cells that didn't exist. I noticed the demos had this issue too. I took a look and I noticed a discrepancy between the spirit of the start/end index calculation and its implementation. This fix addresses errors in the original implementation hopefully without changing the functionality of the layout.

The changes goes like this:
- My understanding of the start and end index calculation is that you want a "window" range where the current page is in the middle and to the "left" is half of the numberOfVisibleItems (i.e. index - left) and the "right" is the other half.
- This calculation is easy when the number is even (numberOfVisibleItems / 2). For odd, instead of forcing numberOfVisibleItems to be even and causing out of bound issues with the total collection view item count, we simply use Int's automatic flooring of division with remainder. So if numberOfVisibleItems is 7, 7/2 = 3.5 = Int(3), and 3 + currentIndex + 3 = 7.
- Switching to this form of calculation, we no longer need to modify the numberOfVisibleItems and if endIndex goes beyond the range, it'll clamp to the numberOfItems.
- The rest of the changes is me doing some renaming so it would be easier for someone new to understand what's being calculated.