### PR TITLE
ignoreUpdateCurrentPage when program set currentPage 

### DIFF
--- a/CollectionViewPagingLayout.podspec
+++ b/CollectionViewPagingLayout.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "CollectionViewPagingLayout"
-  s.version          = "0.1.1"
+  s.version          = "0.1.3"
   s.summary          = "Simple layout for making paging effects with UICollectionView."
  
   s.description      = <<-DESC

--- a/Lib/CollectionViewPagingLayout.swift
+++ b/Lib/CollectionViewPagingLayout.swift
@@ -65,10 +65,10 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
     
     
     // MARK: UICollectionViewLayout
-    var ignoreBoundsChange : Bool = false
+    var ignoreUpdateCurrentPage : Bool = false
     
     override public func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-        !ignoreBoundsChange
+        true
     }
     
     override public func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
@@ -130,7 +130,9 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
     
     override public func invalidateLayout() {
         super.invalidateLayout()
-        updateCurrentPageIfNeeded()
+        if !ignoreUpdateCurrentPage{
+            updateCurrentPageIfNeeded()
+        }
     }
     
     
@@ -175,10 +177,10 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
         offset = max(0, offset)
         offset = min(offset, maxPossibleOffset)
         let contentOffset: CGPoint = scrollDirection == .horizontal ? CGPoint(x: offset, y: 0) : CGPoint(x: 0, y: offset)
-        ignoreBoundsChange = true
+        ignoreUpdateCurrentPage = true
         CATransaction.begin()
         CATransaction.setCompletionBlock({
-            self.ignoreBoundsChange = false
+            self.ignoreUpdateCurrentPage = false
             self.updateCurrentPageIfNeeded(basedOn: contentOffset)
         })
         CATransaction.commit()

--- a/Lib/CollectionViewPagingLayout.swift
+++ b/Lib/CollectionViewPagingLayout.swift
@@ -131,7 +131,9 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
             let contentOffset = scrollDirection == .horizontal ?
                 (collectionView.contentOffset.x + collectionView.contentInset.left) :
                 (collectionView.contentOffset.y + collectionView.contentInset.top)
-            currentPage = Int(round(contentOffset / pageSize))
+            if pageSize > 0 {
+                currentPage = Int(round(contentOffset / pageSize))
+            }
         }
         if currentPage != self.currentPage {
             self.currentPage = currentPage

--- a/Lib/CollectionViewPagingLayout.swift
+++ b/Lib/CollectionViewPagingLayout.swift
@@ -183,8 +183,8 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
             self.ignoreUpdateCurrentPage = false
             self.updateCurrentPageIfNeeded(basedOn: contentOffset)
         })
-        CATransaction.commit()
         collectionView?.setContentOffset(contentOffset, animated: animated)
+        CATransaction.commit()
         
     }
 }

--- a/Lib/CollectionViewPagingLayout.swift
+++ b/Lib/CollectionViewPagingLayout.swift
@@ -39,10 +39,7 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
     }
     
     private var visibleRect: CGRect {
-        guard let collectionView = collectionView else {
-            return .zero
-        }
-        return CGRect(origin: collectionView.contentOffset, size: collectionView.bounds.size)
+        collectionView.map { CGRect(origin: $0.contentOffset, size: $0.bounds.size) } ?? .zero
     }
     
     private var numberOfItems: Int {


### PR DESCRIPTION
ignoreUpdateCurrentPage when program set currentPage, Only update currentPage when animation finished. This will avoid currentPage may temporarily set previous value back when currentPage change. 