### PR TITLE
Fix for exception when there are no sections

### DIFF
--- a/Lib/CollectionViewPagingLayout.swift
+++ b/Lib/CollectionViewPagingLayout.swift
@@ -71,58 +71,63 @@ public class CollectionViewPagingLayout: UICollectionViewLayout {
     }
     
     override public func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        let currentScrollOffset = self.currentScrollOffset
-        let numberOfItems = self.numberOfItems
-        let attributesCount = numberOfVisibleItems ?? numberOfItems
-        let visibleRangeMid = attributesCount / 2
-        let currentPageIndex = Int(round(currentScrollOffset))
-        var initialStartIndex = currentPageIndex - visibleRangeMid
-        var initialEndIndex = currentPageIndex + visibleRangeMid
-        if attributesCount % 2 != 0 {
-            if currentPageIndex < visibleRangeMid {
-                initialStartIndex -= 1
-            } else {
-                initialEndIndex += 1
-            }
-        }
-        let startIndexOutOfBounds = max(0, -initialStartIndex)
-        let endIndexOutOfBounds = max(0, initialEndIndex - numberOfItems)
-        let startIndex = max(0, initialStartIndex - endIndexOutOfBounds)
-        let endIndex = min(numberOfItems, initialEndIndex + startIndexOutOfBounds)
-        
         var attributesArray: [UICollectionViewLayoutAttributes] = []
-        var section = 0
-        var numberOfItemsInSection = collectionView?.numberOfItems(inSection: section) ?? 0
-        var numberOfItemsInPrevSections = 0
-        for index in startIndex..<endIndex {
-            var item = index - numberOfItemsInPrevSections
-            while item >= numberOfItemsInSection {
-                numberOfItemsInPrevSections += numberOfItemsInSection
-                section += 1
-                numberOfItemsInSection = collectionView?.numberOfItems(inSection: section) ?? 0
-                item = index - numberOfItemsInPrevSections
+
+        let numberOfSections = collectionView?.numberOfSections ?? 0
+        if numberOfSections != 0 {
+            let currentScrollOffset = self.currentScrollOffset
+            let numberOfItems = self.numberOfItems
+            let attributesCount = numberOfVisibleItems ?? numberOfItems
+            let visibleRangeMid = attributesCount / 2
+            let currentPageIndex = Int(round(currentScrollOffset))
+            var initialStartIndex = currentPageIndex - visibleRangeMid
+            var initialEndIndex = currentPageIndex + visibleRangeMid
+            if attributesCount % 2 != 0 {
+                if currentPageIndex < visibleRangeMid {
+                    initialStartIndex -= 1
+                } else {
+                    initialEndIndex += 1
+                }
             }
+            let startIndexOutOfBounds = max(0, -initialStartIndex)
+            let endIndexOutOfBounds = max(0, initialEndIndex - numberOfItems)
+            let startIndex = max(0, initialStartIndex - endIndexOutOfBounds)
+            let endIndex = min(numberOfItems, initialEndIndex + startIndexOutOfBounds)
+        
+            var attributesArray: [UICollectionViewLayoutAttributes] = []
+            var section = 0
+            var numberOfItemsInSection = collectionView?.numberOfItems(inSection: section) ?? 0
+            var numberOfItemsInPrevSections = 0
+            for index in startIndex..<endIndex {
+                var item = index - numberOfItemsInPrevSections
+                while item >= numberOfItemsInSection {
+                    numberOfItemsInPrevSections += numberOfItemsInSection
+                    section += 1
+                    numberOfItemsInSection = collectionView?.numberOfItems(inSection: section) ?? 0
+                    item = index - numberOfItemsInPrevSections
+                }
             
-            let cellAttributes = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: item, section: section))
-            let pageIndex = CGFloat(index)
-            let progress = pageIndex - currentScrollOffset
-            var zIndex = Int(-abs(round(progress)))
+                let cellAttributes = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: item, section: section))
+                let pageIndex = CGFloat(index)
+                let progress = pageIndex - currentScrollOffset
+                var zIndex = Int(-abs(round(progress)))
             
-            let cell = collectionView?.cellForItem(at: cellAttributes.indexPath)
+                let cell = collectionView?.cellForItem(at: cellAttributes.indexPath)
             
-            if let cell = cell as? TransformableView {
-                cell.transform(progress: progress)
-                zIndex = cell.zPosition(progress: progress)
+                if let cell = cell as? TransformableView {
+                    cell.transform(progress: progress)
+                    zIndex = cell.zPosition(progress: progress)
+                }
+            
+                if cell == nil || cell is TransformableView {
+                    cellAttributes.frame = visibleRect
+                } else {
+                    cellAttributes.frame = CGRect(origin: CGPoint(x: pageIndex * visibleRect.width, y: 0), size: visibleRect.size)
+                }
+            
+                cellAttributes.zIndex = zIndex
+                attributesArray.append(cellAttributes)
             }
-            
-            if cell == nil || cell is TransformableView {
-                cellAttributes.frame = visibleRect
-            } else {
-                cellAttributes.frame = CGRect(origin: CGPoint(x: pageIndex * visibleRect.width, y: 0), size: visibleRect.size)
-            }
-            
-            cellAttributes.zIndex = zIndex
-            attributesArray.append(cellAttributes)
         }
         return attributesArray
     }


### PR DESCRIPTION
When there are no sections (due to no data) in the collectionview, the exception "request for number of items in section 0 when there are only 0 sections in the collection view" is thrown. This is typically thrown on line 95: var numberOfItemsInSection = collectionView?.numberOfItems(inSection: section) ?? 0

The fix is to check if numberOfSections does not equal zero via an 'if' statement. If it equals zero, it doesn't make sense to iterate through the entire function. Simply return an empty attributesArray instead.