### PR TITLE
Drop iOS 8 support to silence warning from Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "CollectionViewPagingLayout",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v9)
     ],
     products: [
         .library(


### PR DESCRIPTION
This silences the warning from Xcode 12:

```
CollectionViewPagingLayout/Package.swift The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.5.99.
```