### PR TITLE
Keep `viewController.onCurrentPageChanged` when view gets updated

### DIFF
--- a/CollectionViewPagingLayout.podspec
+++ b/CollectionViewPagingLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "CollectionViewPagingLayout"
-  s.version = "1.0.0"
+  s.version = "1.0.1"
   s.summary = "A simple but highly customizable layout for UICollectionView and SwiftUI."
 
   s.description = <<-DESC

--- a/Lib/SwiftUI/PagingCollectionViewControllerBuilder.swift
+++ b/Lib/SwiftUI/PagingCollectionViewControllerBuilder.swift
@@ -55,10 +55,7 @@ public class PagingCollectionViewControllerBuilder<ValueType: Identifiable, Page
         viewController.pageViewBuilder = pageViewBuilder
         viewController.modifierData = modifierData
         viewController.update(list: data, currentIndex: nil)
-        viewController.onCurrentPageChanged = { [data, selection] in
-            guard $0 < data.count else { return }
-            selection?.wrappedValue = data[$0].id
-        }
+        setupOnCurrentPageChanged(viewController)
         return viewController
     }
 
@@ -68,6 +65,17 @@ public class PagingCollectionViewControllerBuilder<ValueType: Identifiable, Page
         }?.offset
         viewController.modifierData = modifierData
         viewController.update(list: data, currentIndex: selectedIndex)
+        setupOnCurrentPageChanged(viewController)
+    }
+
+
+    // MARK: Private functions
+
+    private func setupOnCurrentPageChanged(_ viewController: ViewController) {
+        viewController.onCurrentPageChanged = { [data, selection] in
+            guard $0 < data.count else { return }
+            selection?.wrappedValue = data[$0].id
+        }
     }
 }
 #endif


### PR DESCRIPTION
…it won't break the link between viewcontroller and closure