### PR TITLE
Fix invalid exclude path warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
     targets: [
         .target(
             name: "CollectionViewPagingLayout",
-            path: "Lib",
-            exclude: ["Samples"])
+            path: "Lib")
     ]
 )


### PR DESCRIPTION
According to the [docs](https://developer.apple.com/documentation/swift_packages/target/2880334-exclude) exclude is relative to the target path.

Fixes this warning:
![Untitled](https://user-images.githubusercontent.com/2950214/140591544-514ebbfa-118d-424d-aa88-76f50f624b07.jpg)
