### PR TITLE
Please fix wrong syntax in sample code

### DIFF
--- a/HOW_TO_USE_UIKIT.md
+++ b/HOW_TO_USE_UIKIT.md
@@ -32,12 +32,14 @@ These protocols are highly customizable, you can make tons of different effects 
 Here is a simple example for `ScaleTransformView` which gives you a simple paging with scaling effect:
 ```swift
 extension YourCell: ScaleTransformView {
-    var scaleOptions = ScaleTransformViewOptions(
-        minScale: 0.6,
-        scaleRatio: 0.4,
-        translationRatio: CGPoint(x: 0.66, y: 0.2),
-        maxTranslationRatio: CGPoint(x: 2, y: 0),
-    )
+    var scaleOptions: ScaleTransformViewOptions { 
+        ScaleTransformViewOptions(
+            minScale: 0.6,
+            scaleRatio: 0.4,
+            translationRatio: CGPoint(x: 0.66, y: 0.2),
+            maxTranslationRatio: CGPoint(x: 2, y: 0)
+            )
+    }
 }
 ```
 There is an "options" property for each of these protocols where you can customize the effect, check the struct to find out what each parameter does.          


### PR DESCRIPTION
Extension can not have stored property, but this example is using stored property at extension please change it into computed property. Thank you for good library! 😄